### PR TITLE
Clear varnish cache when simple product goes out of stock

### DIFF
--- a/app/code/community/Aoe/Static/Model/Cache/Control.php
+++ b/app/code/community/Aoe/Static/Model/Cache/Control.php
@@ -163,23 +163,31 @@ class Aoe_Static_Model_Cache_Control
      */
     public function collectTags()
     {
-        if (Mage::registry('product')) {
-            $this->addTag('product-' . Mage::registry('product')->getId());
+        $tags = array();
+        $product = Mage::registry('product');
+        if ($product) {
+            $tags[] = 'product-' . $product->getId();
+            //add child products tags
+            if ($product->getTypeId() == Mage_Catalog_Model_Product_Type_Configurable::TYPE_CODE) {
+                $childProductsIds = $product->getTypeInstance()->getUsedProductIds();
+                foreach($childProductsIds as $id) {
+                    $tags[] = 'product-' . $id;
+                }
+            }
         }
         if (($layer = $this->_getLayer()) && ($layer->getCurrentCategory()->getId() != $layer->getCurrentStore()->getRootCategoryId()) && ($layer->apply()->getProductCollection())) {
             /** @var Mage_Catalog_Model_Layer $layer */
             $ids = $layer->getProductCollection()->getLoadedIds();
-            $tags = array();
             foreach ($ids as $id) {
                 $tags[] = 'product-' . $id;
             }
-            $this->addTag($tags);
         }
         if (Mage::registry('current_category')) {
             /** @var Mage_Catalog_Model_Category $currentCategory */
             $currentCategory = Mage::registry('current_category');
-            $this->addTag('category-' . $currentCategory->getId());
+            $tags[] = 'category-' . $currentCategory->getId();
         }
+        $this->addTag($tags);
         return $this;
     }
 }

--- a/app/code/community/Aoe/Static/Model/Observer.php
+++ b/app/code/community/Aoe/Static/Model/Observer.php
@@ -282,6 +282,30 @@ class Aoe_Static_Model_Observer
     }
 
     /**
+     * Observer for cataloginventory_stock_item_save_after
+     * checking for product going out of stock
+     *
+     * This is needed for catching product availability change after it was sold out
+     *
+     * @param Varien_Event_Observer $observer
+     */
+    public function productOutOfStock($observer) {
+        /** @var $category Mage_CatalogInventory_Model_Stock_Item */
+        $stockItem = $observer->getItem();
+        $originalStockData = $stockItem->getOrigData('is_in_stock');
+
+        if ((!is_null($originalStockData)
+            && $stockItem->getIsInStock() != $originalStockData
+            && $stockItem->getProductId() > 0)
+        || $stockItem->getStockStatusChangedAuto()
+        ) {
+            /** @var $helper Aoe_Static_Helper_Data */
+            $helper = Mage::helper('aoestatic');
+            $helper->purgeTags('product-' . $stockItem->getProductId());
+        }
+    }
+
+    /**
      * shows message in case admin session exists
      *
      * @param string $type    message type (error/success/notice)

--- a/app/code/community/Aoe/Static/etc/config.xml
+++ b/app/code/community/Aoe/Static/etc/config.xml
@@ -197,6 +197,14 @@
                 </observers>
             </catalog_category_product_cat_partial_reindex>
 
+            <cataloginventory_stock_item_save_after>
+                <observers>
+                    <aoestatic>
+                        <class>aoestatic/observer</class>
+                        <method>productOutOfStock</method>
+                    </aoestatic>
+                </observers>
+            </cataloginventory_stock_item_save_after>
         </events>
     </global>
 


### PR DESCRIPTION
Adds tagging of the configurable product single view page with child products
tags.
Listen to the inventory change event and purge tag when product
status has changed.

With this patch configurable product single view page is cleared form varnish when one of the simple products is sold out.

Unfortunately the recent improvements which clears cache on reindexing is not helping here as
Magento calls low level reindex methods directly in the event sales_model_service_quote_submit_success
Mage/CatalogInventory/Model/Observer.php::reindexQuoteInventory

Because of that the indexer events are not triggered => cache was not cleared