### PR TITLE
Fix recently viewed products

### DIFF
--- a/app/code/community/Aoe/Static/controllers/CallController.php
+++ b/app/code/community/Aoe/Static/controllers/CallController.php
@@ -55,6 +55,10 @@ class Aoe_Static_CallController extends Mage_Core_Controller_Front_Action
         $response['sid'] = Mage::getModel('core/session')->getEncryptedSessionId();
 
         if ($currentProductId = $this->getRequest()->getParam('currentProductId')) {
+            Mage::getModel('reports/product_index_viewed')
+                ->setProductId($currentProductId)
+                ->save()
+                ->calculate();
             Mage::getSingleton('catalog/session')->setLastViewedProductId($currentProductId);
         }
 


### PR DESCRIPTION
(works if you have an ajax call on product single view page)

How to reproduce the issue:
1. Put recently viewed block on some page.
2. make sure products pagees are cached by varnish, and there is a aoe_static ajax request made on the product page.
3. in other browser go to these cached product pages
4. recently viewed block will stay empty.