### PR TITLE
Replace the placeholder not only its content.

### DIFF
--- a/js/aoestatic/common.js
+++ b/js/aoestatic/common.js
@@ -126,7 +126,7 @@ var Aoe_Static = {
                 data,
                 function (response) {
                     for(var id in response.blocks) {
-                        $('#' + id).html(response.blocks[id]);
+                        $('#' + id).replaceWith(response.blocks[id]);
                         localStorage.setItem('aoe_static_blocks_' + data.getBlocks[id], response.blocks[id]);
                     }
                     jQuery('body').trigger('aoestatic_afterblockreplace', response);


### PR DESCRIPTION
`.html()` simply replaces the inner content not the element itself. For a placeholder block it felt strange that after a replacement the placeholder is still present and somewhat clutters the markup. With `.replaceWith()` that could be solved.
