### PR TITLE
Prevent calling getStoreConfigFlag too early in the bootstrap

### DIFF
--- a/app/code/community/Aoe/Static/Helper/Data.php
+++ b/app/code/community/Aoe/Static/Helper/Data.php
@@ -18,7 +18,7 @@ class Aoe_Static_Helper_Data extends Mage_Core_Helper_Abstract
     /**
      * Flag for verbose logging
      */
-    protected $verboseLogging = false;
+    protected $verboseLogging = null;
 
     /**
      * @return Aoe_Static_Model_Config
@@ -31,8 +31,22 @@ class Aoe_Static_Helper_Data extends Mage_Core_Helper_Abstract
         return $this->_config;
     }
 
-    public function __construct() {
-        $this->verboseLogging = Mage::getStoreConfigFlag('dev/aoestatic/verboseLogging');
+    /**
+     * Checks if logging is enabled.
+     *
+     * @return bool
+     */
+    public function isVerboseLoggingEnabled() {
+        if (is_bool($this->verboseLogging)) {
+            return $this->verboseLogging;
+        }
+        //do not try to call getStoreConfigFlag too early in the bootstrap (e.g. when store is not yet initialized)
+        if (Mage::registry('controller')) {
+            $this->verboseLogging = Mage::getStoreConfigFlag('dev/aoestatic/verboseLogging');
+            return $this->verboseLogging;
+        } else {
+            return false;
+        }
     }
 
     /**
@@ -207,7 +221,7 @@ class Aoe_Static_Helper_Data extends Mage_Core_Helper_Abstract
      * @param bool $forceLog
      */
     public function log($message, $level = null, $file = '', $forceLog = false) {
-        if ($forceLog || $this->verboseLogging) {
+        if ($forceLog || $this->isVerboseLoggingEnabled()) {
             Mage::log($message, $level, $file, $forceLog);
         }
     }


### PR DESCRIPTION
In some edge cases Magento clears cache before stores are initialized.
Then the Aoe_Static observer is called which runs getStoreConfigFlag,
which results in throwing Store_Exception and showing 404 page.

This pach tries to detect whether Magento is laready initalized or not,
by checking 'controller' registry.
Untill this registry is set, Aoe_Static will not try to check
storeConfigFlag (and will not log anything).

We should discuss:
1. what is the best way to detect whether it's safe to call getStoreConfigFlag
2. what should be the default behaviour before we know what is set in config
maybe we should acces the config directly instead of going through getStoreConfigFlag?

This is a followup to https://github.com/AOEpeople/Aoe_Static/pull/11

